### PR TITLE
Changed date input open/close to work off click handlers instead of f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,11 +265,9 @@ render: function() {
 		<tr>
 			<td>value</td>
 			<td>String</td>
-			<td>new Date()
-				<br />.toISOString()
-				<br />.slice(0, 10)</td>
+			<td>new Date()</td>
 			<td>no</td>
-			<td>A full-date to set the input to. Can be used to set an initial value</td>
+			<td>A date to set the input to. Can be used to set an initial value</td>
 		</tr>
 	</tbody>
 </table>

--- a/demo/date-input/index.jsx
+++ b/demo/date-input/index.jsx
@@ -7,21 +7,21 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 class Parent extends React.Component {
-	
+
 	constructor (props) {
 		super(props);
-		this.state = { date: new Date().toISOString().slice(0, 10) };
+		this.state = { date: new Date() };
 		this.setDate = this.setDate.bind(this);
 	}
-	
+
 	setDate (date) {
 		this.setState({ date });
 	}
-	
+
 	render () {
 		return (
 			<div>
-				<div>{'this.state.date = '}{this.state.date}</div>
+				<div>{'this.state.date = '}{this.state.date.toString()}</div>
 				<Carpentry.DateInput setValue={this.setDate} format="DD / MM / YY">
 					<img src="date-input/calendar.png" />
 				</Carpentry.DateInput>

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<title>Demo</title>
+		<meta name="viewport" content="width=device-width">
 		<style>
 			body {
 				font-family: sans-serif;

--- a/src/date-input/calendar.jsx
+++ b/src/date-input/calendar.jsx
@@ -4,42 +4,44 @@ import Navbar from './navbar';
 import React from 'react';
 
 export default React.createClass({
-	
+
 	displayName: 'Calendar',
-	
+
 	getInitialState() {
 		return {
 			viewDate: new Date(this.props.selectedDate.getTime()),
 			level: 0
 		};
 	},
-	
-	onCalendarMouseDown(e) {
-		// Prevent button losing focus whilst navigating calendar
-		e.preventDefault();
-	},
-	
+
 	setViewDate(date) {
 		this.setState({
 			viewDate: date
 		});
 	},
-	
+
 	setLevel(modifier) {
 		const newLevel = this.state.level + modifier;
-		
+
 		if (0 <= newLevel && newLevel <= 2) {
 			this.setState({
 				level: newLevel
 			});
 		}
 	},
-	
+
+	onPositionerClick() {
+		this.props.setVisible(false);
+	},
+
+	onCalendarClick(e) {
+		e.stopPropagation();
+	},
+
 	render() {
 		return (
-			<div className={this.props.className + '__positioner'}>
-				<div className={this.props.className + '__calendar'}
-					onMouseDown={this.onCalendarMouseDown}>
+			<div className={this.props.className + '__positioner'} onClick={this.onPositionerClick}>
+				<div className={this.props.className + '__calendar'} onClick={this.onCalendarClick}>
 					<Navbar className={this.props.className} viewDate={this.state.viewDate}
 						level={this.state.level} monthNames={this.props.monthNames}
 						setViewDate={this.setViewDate} setLevel={this.setLevel} />

--- a/src/date-input/index.jsx
+++ b/src/date-input/index.jsx
@@ -2,7 +2,6 @@ import Calendar from './calendar';
 import Dates from '../helpers/dates';
 import Numbers from '../helpers/numbers';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import Styles from './styles';
 
 export default React.createClass({
@@ -28,7 +27,7 @@ export default React.createClass({
 		monthNames: React.PropTypes.arrayOf(React.PropTypes.string),
 		setValue: React.PropTypes.func.isRequired,
 		today: React.PropTypes.string,
-		value: React.PropTypes.string
+		value: React.PropTypes.object
 	},
 
 	getDefaultProps() {
@@ -51,27 +50,6 @@ export default React.createClass({
 		};
 	},
 
-	onInputMouseDown(e) {
-		// Prevent typing into input or text selection
-		e.preventDefault();
-	},
-
-	onButtonMouseDown(e) {
-		// Prevent passing focus down to children of button
-		e.preventDefault();
-	},
-
-	onButtonClick() {
-		// Manually focus button due to preventDefault
-		ReactDOM.findDOMNode(this.refs.button).focus();
-		this.setVisible(!this.state.visible);
-	},
-
-	onButtonBlur() {
-		// Automatically close calendar upon blur
-		this.setVisible(false);
-	},
-
 	setSelectedDate(date) {
 		this.setState({
 			selectedDate: date
@@ -86,22 +64,22 @@ export default React.createClass({
 		});
 	},
 
+	onDateInputClick() {
+		this.setVisible(!this.state.visible);
+	},
+
 	render() {
-		const dateString = Dates.toFormattedString(this.state.selectedDate,
-			this.props.format);
+		const dateString = Dates.toFormattedString(this.state.selectedDate, this.props.format);
 
 		return (
-			<div className={this.props.className}>
+			<div className={this.props.className} onClick={this.onDateInputClick}>
 				<style type="text/css">{Styles(this.props.className)}</style>
 				<div className={this.props.className + '__table'}>
 					<div className={this.props.className + '__cell'}>
-						<input className={this.props.className + '__input'} value={dateString}
-							onMouseDown={this.onInputMouseDown} onChange={()=>{}} />
+						<input className={this.props.className + '__input'} readOnly={true} value={dateString} />
 					</div>
 					<div className={this.props.className + '__cell'}>
-						<button className={this.props.className + '__button'} ref="button"
-							onMouseDown={this.onButtonMouseDown} onClick={this.onButtonClick}
-							onBlur={this.onButtonBlur}>
+						<button className={this.props.className + '__button'}>
 							{this.props.children}
 						</button>
 					</div>


### PR DESCRIPTION
Displaying/hiding the date input calendar based off of focus was originally done to support opening via tabbing to the input however it's causing issues on various mobile devices.

Implemented change to simply open/close using click handlers.

Also updated docs and prop validation to reflect previous change to the value prop.